### PR TITLE
Retroactively add release_time to old artifact JSONs

### DIFF
--- a/artifact/1.json
+++ b/artifact/1.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/1/authlib-injector-1.0.1-4405964.jar",
   "checksums": {
     "sha256": "c8e21d46b27d311dc70f7033b851d40a754ba7a5d3fa59b5994811e019d8c447"
-  }
+  },
+  "release_time": "2018-06-28T21:14:02+08:00"
 }

--- a/artifact/10.json
+++ b/artifact/10.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/10/authlib-injector-1.0.10-8aa3f20.jar",
   "checksums": {
     "sha256": "6cb153873724212c4e939725ef74864e1fc3c7e7882c59d639ae9653782845cd"
-  }
+  },
+  "release_time": "2018-06-28T21:28:14+08:00"
 }

--- a/artifact/11.json
+++ b/artifact/11.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/11/authlib-injector-1.1.11-bfa2629.jar",
   "checksums": {
     "sha256": "d418a1187da242b0bb410786d2a20c64413302590003bbfbc613e9c30133fa63"
-  }
+  },
+  "release_time": "2018-06-28T21:28:23+08:00"
 }

--- a/artifact/12.json
+++ b/artifact/12.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/12/authlib-injector-1.1.12-83dcd83.jar",
   "checksums": {
     "sha256": "24f6c0cf0393cb59bc157cbeea7e689f90b864125b95780da63f35e3b5863796"
-  }
+  },
+  "release_time": "2018-06-28T21:28:29+08:00"
 }

--- a/artifact/13.json
+++ b/artifact/13.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/13/authlib-injector-1.1.13-c7866c1.jar",
   "checksums": {
     "sha256": "2eaece92768691e085657ebcc9bf81f12611fb003d33c01041403c4c741568eb"
-  }
+  },
+  "release_time": "2018-06-28T21:28:35+08:00"
 }

--- a/artifact/14.json
+++ b/artifact/14.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/14/authlib-injector-1.1.14-7710506.jar",
   "checksums": {
     "sha256": "0ef5b030d72b00973aafd9c4d1cd844f510cfe063410e6f8357920bf59241f6d"
-  }
+  },
+  "release_time": "2018-06-28T21:28:42+08:00"
 }

--- a/artifact/15.json
+++ b/artifact/15.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/15/authlib-injector-1.1.15-11c952d.jar",
   "checksums": {
     "sha256": "f45021f62459a7edc02068485c62d2fd3f06e6ceb0c8a0c9a3d3ef8d661c2a48"
-  }
+  },
+  "release_time": "2018-06-28T21:28:49+08:00"
 }

--- a/artifact/16.json
+++ b/artifact/16.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/16/authlib-injector-1.1.16-f460e0e.jar",
   "checksums": {
     "sha256": "492ae174bd51e9d4d2dc2952882b4fbe3227ae01ef2909cd326565190d1a491f"
-  }
+  },
+  "release_time": "2018-06-28T21:28:55+08:00"
 }

--- a/artifact/17.json
+++ b/artifact/17.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/17/authlib-injector-1.1.17-4b3b0be.jar",
   "checksums": {
     "sha256": "fc6f0235d536652d519202215fa87859437cafdbddae8d6e9cb17088cb17b498"
-  }
+  },
+  "release_time": "2018-06-28T21:29:00+08:00"
 }

--- a/artifact/18.json
+++ b/artifact/18.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/18/authlib-injector-1.1.18-daa6fb4.jar",
   "checksums": {
     "sha256": "628c9a2e576caaa8e90045e019385284983346e4039f50314e40a8bad8e6c51e"
-  }
+  },
+  "release_time": "2018-06-29T13:25:41+00:00"
 }

--- a/artifact/19.json
+++ b/artifact/19.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/19/authlib-injector-1.1.19-36fc21d.jar",
   "checksums": {
     "sha256": "d153e49e5fa175b84c28a17f2c90cddb8ee00f0dffcf7648b1a4bd26e2c38b80"
-  }
+  },
+  "release_time": "2018-09-30T13:17:16+00:00"
 }

--- a/artifact/2.json
+++ b/artifact/2.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/2/authlib-injector-1.0.2-e47b187.jar",
   "checksums": {
     "sha256": "57652a1c9c6d2a266b372877706ee87fc6042912c82fe9cf9b8c48aa798f537c"
-  }
+  },
+  "release_time": "2018-06-28T21:14:02+08:00"
 }

--- a/artifact/20.json
+++ b/artifact/20.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/20/authlib-injector-1.1.20-940a3d5.jar",
   "checksums": {
     "sha256": "11c38c0a42ac8d38575c6be35addfdacc474ead46f808b01329eb002808ec005"
-  }
+  },
+  "release_time": "2018-10-20T13:43:43+00:00"
 }

--- a/artifact/21.json
+++ b/artifact/21.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/21/authlib-injector-1.1.21-f242b97.jar",
   "checksums": {
     "sha256": "7ec5387965203d05cc81b4019c386f8162904f9fe9db283bef6b5ec8a2ff4e8d"
-  }
+  },
+  "release_time": "2018-10-20T13:49:31+00:00"
 }

--- a/artifact/22.json
+++ b/artifact/22.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/22/authlib-injector-1.1.22-69c4067.jar",
   "checksums": {
     "sha256": "16a291197fbd1175b3922f4a9fe047278f9b2428b88228853ae6cdc552f9b98d"
-  }
+  },
+  "release_time": "2018-11-23T16:11:54+00:00"
 }

--- a/artifact/23.json
+++ b/artifact/23.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/23/authlib-injector-1.1.23-209ba0e.jar",
   "checksums": {
     "sha256": "a71e7c8dece21b4a15136f07769f5e2e8d595e32e824116900a49a66aec0a88a"
-  }
+  },
+  "release_time": "2018-11-24T17:16:56+00:00"
 }

--- a/artifact/24.json
+++ b/artifact/24.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/24/authlib-injector-1.1.24-fe7cb0b.jar",
   "checksums": {
     "sha256": "5d79c5aee4a41e76463ff42cf7e0a673285b01eb0ac31449ad6810db1e61a1ea"
-  }
+  },
+  "release_time": "2018-12-31T13:03:32+00:00"
 }

--- a/artifact/25.json
+++ b/artifact/25.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/25/authlib-injector-1.1.25-37e97b1.jar",
   "checksums": {
     "sha256": "4f504faf977712892263575ff34e29bdb12d3946650cf8e790463480b8f7a63f"
-  }
+  },
+  "release_time": "2019-01-19T15:40:25+00:00"
 }

--- a/artifact/26.json
+++ b/artifact/26.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/26/authlib-injector-1.1.26-41a7a47.jar",
   "checksums": {
     "sha256": "c63fa292fd4b03d69762511fdbcabdcc85567269475f799cbd52a292dd7c88b1"
-  }
+  },
+  "release_time": "2019-02-14T05:26:31+00:00"
 }

--- a/artifact/27.json
+++ b/artifact/27.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/27/authlib-injector-1.1.27-5ef5f8e.jar",
   "checksums": {
     "sha256": "eca3d662963a58ed2f44fa723d6dca1a840b244b631b3c226df8df22a9104ca8"
-  }
+  },
+  "release_time": "2020-04-10T16:05:12+00:00"
 }

--- a/artifact/28.json
+++ b/artifact/28.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/28/authlib-injector-1.1.28-682ecc6.jar",
   "checksums": {
     "sha256": "f553a02be9908b15c8ef6046fb7a91bd1589da52f308e67bce8ed8d4c255748b"
-  }
+  },
+  "release_time": "2020-04-29T02:46:56+00:00"
 }

--- a/artifact/29.json
+++ b/artifact/29.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/29/authlib-injector-1.1.29.jar",
   "checksums": {
     "sha256": "249a47357ab66c25b3503e9a88f2c0adacfad2f4a270c2d1a1fd41c70d9d30e4"
-  }
+  },
+  "release_time": "2020-06-20T14:30:17Z"
 }

--- a/artifact/3.json
+++ b/artifact/3.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/3/authlib-injector-1.0.3-3185f73.jar",
   "checksums": {
     "sha256": "38a9192517670450e6ec544f3ae177daaae3c086f0cb61c8ba31215f294c06d2"
-  }
+  },
+  "release_time": "2018-06-28T21:14:02+08:00"
 }

--- a/artifact/30.json
+++ b/artifact/30.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/30/authlib-injector-1.1.30.jar",
   "checksums": {
     "sha256": "84b7a4a1098492dc5acdf5859f022db2f6a9bb59de51a57061d6e8308d70640b"
-  }
+  },
+  "release_time": "2020-08-15T03:08:38Z"
 }

--- a/artifact/31.json
+++ b/artifact/31.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/31/authlib-injector-1.1.31.jar",
   "checksums": {
     "sha256": "711bfaa39cd9fd978b1154edd38300b9e8bdd882a758b6902b71174b43cd2c2c"
-  }
+  },
+  "release_time": "2020-08-23T07:06:55Z"
 }

--- a/artifact/32.json
+++ b/artifact/32.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/32/authlib-injector-1.1.32.jar",
   "checksums": {
     "sha256": "8aad9b8e81d31ac63573865a66f6f743496263d157ac79957305b0bd63888a53"
-  }
+  },
+  "release_time": "2020-08-27T04:21:52Z"
 }

--- a/artifact/33.json
+++ b/artifact/33.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/33/authlib-injector-1.1.33.jar",
   "checksums": {
     "sha256": "fd23ad834e1a673264981807f05963a7cdca3ba8681d4b3ebfabc2fc9e236438"
-  }
+  },
+  "release_time": "2020-09-11T23:27:27Z"
 }

--- a/artifact/34.json
+++ b/artifact/34.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/34/authlib-injector-1.1.34.jar",
   "checksums": {
     "sha256": "7926b1502f934c512909ada1fe9ca246ace5c80e9e65c1ef758955a23376c22a"
-  }
+  },
+  "release_time": "2020-10-17T17:18:31Z"
 }

--- a/artifact/35.json
+++ b/artifact/35.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/35/authlib-injector-1.1.35.jar",
   "checksums": {
     "sha256": "1ea67a2f05a049b400a0630cd12e65b6802b78a9910440b734003ac15f61ecca"
-  }
+  },
+  "release_time": "2021-05-14T06:55:24Z"
 }

--- a/artifact/36.json
+++ b/artifact/36.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/36/authlib-injector-1.1.36.jar",
   "checksums": {
     "sha256": "809d19266d9ebe1cd213b676570a66aa377fe4108153398fca24dcc5188ec582"
-  }
+  },
+  "release_time": "2021-06-11T10:34:18Z"
 }

--- a/artifact/37.json
+++ b/artifact/37.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/37/authlib-injector-1.1.37.jar",
   "checksums": {
     "sha256": "712e5c1c20bf4b50a7b1f304972cec71ad3f82b30a150c088e8322c4ba757711"
-  }
+  },
+  "release_time": "2021-06-11T19:55:54Z"
 }

--- a/artifact/38.json
+++ b/artifact/38.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/38/authlib-injector-1.1.38.jar",
   "checksums": {
     "sha256": "c79416acc317eaade53307342d894ed6cf787c754282ae9de79e37ca28253941"
-  }
+  },
+  "release_time": "2021-06-13T22:05:49Z"
 }

--- a/artifact/39.json
+++ b/artifact/39.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/39/authlib-injector-1.1.39.jar",
   "checksums": {
     "sha256": "d743dee655a1b187372398c6eb270f67503733ad03531bbc74d2bcc6f2bd0ffa"
-  }
+  },
+  "release_time": "2021-08-20T20:30:11Z"
 }

--- a/artifact/4.json
+++ b/artifact/4.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/4/authlib-injector-1.0.4-014eb57.jar",
   "checksums": {
     "sha256": "c0cd1270262ff14d07578d835483551437aefe9ac9ff0dec9ab8f5b1e0908c64"
-  }
+  },
+  "release_time": "2018-06-28T21:14:02+08:00"
 }

--- a/artifact/40.json
+++ b/artifact/40.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/40/authlib-injector-1.1.40.jar",
   "checksums": {
     "sha256": "4c264059f489b3339e821245d9144709494352837b9a3b1abdf7071fca2ebee6"
-  }
+  },
+  "release_time": "2021-11-18T13:49:40Z"
 }

--- a/artifact/41.json
+++ b/artifact/41.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/41/authlib-injector-1.1.41.jar",
   "checksums": {
     "sha256": "64c2fc525861f672afb834bcc08fd46c4c844bfa3ea5b215995e3f34b599713e"
-  }
+  },
+  "release_time": "2022-03-11T05:48:00Z"
 }

--- a/artifact/42.json
+++ b/artifact/42.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/42/authlib-injector-1.1.42.jar",
   "checksums": {
     "sha256": "c1b5c061809eaffb078c344723e636915e118a9a9e2446562e6289065ce18c3f"
-  }
+  },
+  "release_time": "2022-03-15T18:07:46Z"
 }

--- a/artifact/43.json
+++ b/artifact/43.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/43/authlib-injector-1.1.43.jar",
   "checksums": {
     "sha256": "6da1053212036674587283013e354cafc3f8a360cfc9c111eccd2cf4d9cfbe6b"
-  }
+  },
+  "release_time": "2022-04-20T17:21:18Z"
 }

--- a/artifact/44.json
+++ b/artifact/44.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/44/authlib-injector-1.1.44.jar",
   "checksums": {
     "sha256": "9bfc5299b93c44df8dcff7d88051f78d4142b5ac3f3cbdba80878e3b52b2a526"
-  }
+  },
+  "release_time": "2022-05-03T13:42:48Z"
 }

--- a/artifact/45.json
+++ b/artifact/45.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/45/authlib-injector-1.1.45.jar",
   "checksums": {
     "sha256": "6e209f30ec10b7765205e7c7e7461ab26fd7f1153da83719848553698cff2f40"
-  }
+  },
+  "release_time": "2022-06-06T18:02:59Z"
 }

--- a/artifact/46.json
+++ b/artifact/46.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/46/authlib-injector-1.1.46.jar",
   "checksums": {
     "sha256": "de4e6f0eaa1f1af78e35bee5d19f20da96e3118f5a22c3cf4b476105a5713d80"
-  }
+  },
+  "release_time": "2022-07-02T06:06:24Z"
 }

--- a/artifact/47.json
+++ b/artifact/47.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/47/authlib-injector-1.1.47.jar",
   "checksums": {
     "sha256": "45336952bbedb5cd848321172abe2c2baf0a864826f27a79fed52e3408c0dbc1"
-  }
+  },
+  "release_time": "2022-07-14T11:37:08Z"
 }

--- a/artifact/48.json
+++ b/artifact/48.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/48/authlib-injector-1.2.0.jar",
   "checksums": {
     "sha256": "4108f8a8756f98c5a12b9ebe5282397e6642af84ab643ff70283e95760ef3e2c"
-  }
+  },
+  "release_time": "2022-08-04T16:53:00Z"
 }

--- a/artifact/49.json
+++ b/artifact/49.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/49/authlib-injector-1.2.1.jar",
   "checksums": {
     "sha256": "501329f23a2650d71730283b9360a3444f313708dfd76bd9f6ccc10f86ba57a6"
-  }
+  },
+  "release_time": "2022-08-05T17:11:21Z"
 }

--- a/artifact/50.json
+++ b/artifact/50.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/50/authlib-injector-1.2.2.jar",
   "checksums": {
     "sha256": "00d77e557d3989c8cdeb5f12859c1262ba853558bfce495aecbeda8d3bc02956"
-  }
+  },
+  "release_time": "2023-03-25T10:42:43Z"
 }

--- a/artifact/51.json
+++ b/artifact/51.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/51/authlib-injector-1.2.3.jar",
   "checksums": {
     "sha256": "d3ec36486b0a5ab5a16069733cd8d749950c2d62e1bdacaf27864b30b92c1c7f"
-  }
+  },
+  "release_time": "2023-06-11T18:47:31Z"
 }

--- a/artifact/6.json
+++ b/artifact/6.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/6/authlib-injector-1.0.6-28fcbd2.jar",
   "checksums": {
     "sha256": "6257324d866c4c07cfc6df3af351efdc4bba5ba882628750f8c01e0a2d9ffec8"
-  }
+  },
+  "release_time": "2018-06-28T21:14:02+08:00"
 }

--- a/artifact/7.json
+++ b/artifact/7.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/7/authlib-injector-1.0.7-5015962.jar",
   "checksums": {
     "sha256": "8cb665eb31035865f2a21c5b3a6b536672d076d66a31ab49bc6c9ad27d13391e"
-  }
+  },
+  "release_time": "2018-06-28T21:15:12+08:00"
 }

--- a/artifact/8.json
+++ b/artifact/8.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/8/authlib-injector-1.0.8-feab914.jar",
   "checksums": {
     "sha256": "822ca4c5a324aeb0eef338005c0a4fa1deb1f47c28e0a36e0b609b42b3f44435"
-  }
+  },
+  "release_time": "2018-06-28T21:26:23+08:00"
 }

--- a/artifact/9.json
+++ b/artifact/9.json
@@ -4,5 +4,6 @@
   "download_url": "https://authlib-injector.yushi.moe/artifact/9/authlib-injector-1.0.9-1731f0b.jar",
   "checksums": {
     "sha256": "f4dda881ddd6f06833d2eac152bbf78e6714bfcef675e60d2acf9cce35ac602e"
-  }
+  },
+  "release_time": "2018-06-28T21:28:04+08:00"
 }


### PR DESCRIPTION
For https://github.com/yushijinhun/authlib-injector/issues/219.

See also https://github.com/yushijinhun/authlib-injector/pull/222.

For builds 28 and earlier, I used the timestamp of the commit from "authlib-injector Deploy Bot". For newer builds, I used the published_at date of the GitHub release.